### PR TITLE
Run auto-update workflow at least once a day via cron

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -3,7 +3,7 @@ name: Automatically create PR on a new version
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 3 * * *'
 
 jobs:
   check_update:


### PR DESCRIPTION
We've updated the signing pipelines, and the cron schedule is no longer needed. But just in case, we will leave it on to run at least once a day.